### PR TITLE
Assume role from EC2 instance fix

### DIFF
--- a/src/Cloudfront.php
+++ b/src/Cloudfront.php
@@ -16,15 +16,16 @@ class Cloudfront
     {
         $this->config = $config;
 
-        if (! empty($this->config['key']) && ! empty($this->config['secret'])) {
-            $credentials = Arr::only($this->config, ['key', 'secret', 'token']);
-        }
-
-        $this->cloudfront = new CloudfrontClient([
+        $clientConfig = [
             'version' => '2020-05-31',
             'region' => $config['region'],
-            'credentials' => $credentials ?? false,
-        ]);
+        ];
+
+        if (! empty($this->config['key']) && ! empty($this->config['secret'])) {
+            $clientConfig['credentials'] = Arr::only($this->config, ['key', 'secret', 'token']);
+        }
+
+        $this->cloudfront = new CloudfrontClient($clientConfig);
     }
 
     /**


### PR DESCRIPTION
By passing the credentials as false it prevent the AWS SDK from assuming the role from the EC2 instance. Might be a recent update to the AWS PHP SDK.